### PR TITLE
Use non-absolute path for youtube-dl

### DIFF
--- a/youtube-sync.sh
+++ b/youtube-sync.sh
@@ -15,4 +15,4 @@ else
 	exit 1
 fi
 
-./youtube-dl -i -f bestvideo+bestaudio --merge-output-format mkv -o "SYNC/$1/ID/%(id)s.mkv" "$URL"
+youtube-dl -i -f bestvideo+bestaudio --merge-output-format mkv -o "SYNC/$1/ID/%(id)s.mkv" "$URL"

--- a/youtube-update-metadata.sh
+++ b/youtube-update-metadata.sh
@@ -15,13 +15,13 @@ for filen in SYNC/$1/ID/*.mkv; do
 		if [[ "$filen" =~ /([^/]+)\.mkv$ ]]; then
 			ID=${BASH_REMATCH[1]};
 			echo -n "Updating metadata ($num_current/$num_total): $ID...";
-			TITLE=$(./youtube-dl --get-filename -o '%(title)s' "$ID");
+			TITLE=$(youtube-dl --get-filename -o '%(title)s' "$ID");
 			if [ -z "$TITLE" ]; then
 				echo " [Error] Video might be down. We'll keep the old link."
 			else
 				echo " [OK]"
 				echo -n "$TITLE" > SYNC/$1/META/$ID.title
-				DESCRIPTION=$(./youtube-dl --get-description "$ID");
+				DESCRIPTION=$(youtube-dl --get-description "$ID");
 				if [ -n "$DESCRIPTION" ]; then
 					echo "$DESCRIPTION" > SYNC/$1/META/$ID.description
 				fi


### PR DESCRIPTION
This makes it work for the general case, like youtube-dl installed with apt-get/yum. It will break your specific case, but I suggest handling that within .bashrc or similar.
