### PR TITLE
Fix youtube-dl agument problem to support video ID starting with "-" and add "--missing-only" argument

### DIFF
--- a/youtube-update-metadata.sh
+++ b/youtube-update-metadata.sh
@@ -3,27 +3,43 @@
 if [ -z "$1" ]; then
 	>&2 echo "Missing sync directory name."
 	exit 1
+else
+    name="$1"
 fi
 
-mkdir -p SYNC/$1/META
+domissing=0
+if [ x"$2" = "x--missing-only" ]; then
+	echo "Only fetching missing metadata"
+	domissing=1
+fi
 
-num_total=$(find "SYNC/$1/ID/" -maxdepth 1 -name "*.mkv" | wc -l)
+mkdir -p SYNC/$name/META
+
+num_total=$(find "SYNC/$name/ID/" -maxdepth 1 -name "*.mkv" | wc -l)
 num_current=1
 
-for filen in SYNC/$1/ID/*.mkv; do
+for filen in SYNC/$name/ID/*.mkv; do
 	if [ -f "$filen" ]; then
 		if [[ "$filen" =~ /([^/]+)\.mkv$ ]]; then
 			ID=${BASH_REMATCH[1]};
+			titlefile=SYNC/$name/META/$ID.title
+			descfile=SYNC/$name/META/$ID.description
+			if [ $domissing -eq 1 \
+					-a -f $titlefile -a -f $descfile ]; then
+				echo "Skipping known meta for $ID"
+				num_current=$((num_current+1))
+				continue
+			fi
 			echo -n "Updating metadata ($num_current/$num_total): $ID...";
 			TITLE=$(youtube-dl --get-filename -o '%(title)s' -- "$ID");
 			if [ -z "$TITLE" ]; then
 				echo " [Error] Video might be down. We'll keep the old link."
 			else
 				echo " [OK]"
-				echo -n "$TITLE" > SYNC/$1/META/$ID.title
+				echo -n "$TITLE" > $titlefile
 				DESCRIPTION=$(youtube-dl --get-description -- "$ID");
 				if [ -n "$DESCRIPTION" ]; then
-					echo "$DESCRIPTION" > SYNC/$1/META/$ID.description
+					echo "$DESCRIPTION" > $descfile
 				fi
 			fi
 		fi

--- a/youtube-update-metadata.sh
+++ b/youtube-update-metadata.sh
@@ -15,13 +15,13 @@ for filen in SYNC/$1/ID/*.mkv; do
 		if [[ "$filen" =~ /([^/]+)\.mkv$ ]]; then
 			ID=${BASH_REMATCH[1]};
 			echo -n "Updating metadata ($num_current/$num_total): $ID...";
-			TITLE=$(youtube-dl --get-filename -o '%(title)s' "$ID");
+			TITLE=$(youtube-dl --get-filename -o '%(title)s' -- "$ID");
 			if [ -z "$TITLE" ]; then
 				echo " [Error] Video might be down. We'll keep the old link."
 			else
 				echo " [OK]"
 				echo -n "$TITLE" > SYNC/$1/META/$ID.title
-				DESCRIPTION=$(youtube-dl --get-description "$ID");
+				DESCRIPTION=$(youtube-dl --get-description -- "$ID");
 				if [ -n "$DESCRIPTION" ]; then
 					echo "$DESCRIPTION" > SYNC/$1/META/$ID.description
 				fi


### PR DESCRIPTION
Fixes a problem with being unable to download metadata for IDs starting with "-", such as:

```

+ echo -n 'Updating metadata (61/1214): -3HplolDjOg...'
Updating metadata (61/1214): -3HplolDjOg...++ youtube-dl --get-filename -o '%(ti
tle)s' -3HplolDjOg
Usage: youtube-dl [OPTIONS] URL [URL...]

youtube-dl: error: no such option: -3
+ TITLE=
+ '[' -z '' ']'
+ echo ' [Error] Video might be down. We'\''ll keep the old link.'
 [Error] Video might be down. We'll keep the old link.


```

(Ran with bash -x)
