### PR TITLE
fix default format & small doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ tree SYNC/
 SYNC/
 └── LADYBABY
     └── META
+        ├── format
         └── source
 
 2 directories, 1 file

--- a/youtube-sync
+++ b/youtube-sync
@@ -85,7 +85,7 @@ function set_default_option {
 }
 
 function set_default_options {
-	set_default_option "$1" "format" "bestvideo+bestaudio"
+	set_default_option "$1" "format" "bestvideo+bestaudio/best"
 }
 
 function sync {


### PR DESCRIPTION
citing my commit messages:

> small doc fix reg. 'format' META file
>
> in ”Step 1: setup a profile“, add the 'format' file.

and

> fix default format
> 
> Since the end of April 2015 and version 2015.04.26, youtube-dl uses -f bestvideo+bestaudio/best as the default format selection,  
> see https://github.com/ytdl-org/youtube-dl/issues/5447 and https://github.com/ytdl-org/youtube-dl/pull/5456.
> 
> =fixup for commit fe6682a (#8)
